### PR TITLE
Pearson Correlation detector

### DIFF
--- a/anomaly-detector.yml
+++ b/anomaly-detector.yml
@@ -12,9 +12,12 @@ dependencies:
 - mccabe=0.6.1=py36hb41005a_1
 - mkl=2018.0.1=h2108138_4
 - numpy=1.14.0=py36h4a99626_1
+- pandas=0.22.0=py36h6538335_0
 - pip=9.0.1=py36h226ae91_4
 - pylint=1.8.2=py36_0
 - python=3.6.4=h6538335_1
+- python-dateutil=2.6.1=py36h509ddcb_1
+- pytz=2017.3=py36h1d3fa6b_0
 - setuptools=38.4.0=py36_0
 - six=1.11.0=py36h4db2310_1
 - vc=14=h0510ff6_3

--- a/src/detectors/LinearPearsonAnomalyDetector.py
+++ b/src/detectors/LinearPearsonAnomalyDetector.py
@@ -1,0 +1,30 @@
+import pandas as pd
+
+class LinearPearsonAnomalyDetector:
+    def __init__(self, initial_corr_threshold = 0.9):
+        self.initial_corr_threshold = initial_corr_threshold
+        self.dataframe = None
+        self.corr_threshold = None
+
+    def __generate_dataframe(self, values):
+        dict_from_values = {}
+        dict_from_values['variable'] = values
+        dict_from_values['index'] = range(len(values))
+        return pd.DataFrame(dict_from_values)
+
+    def __get_pearson(self, dataframe):
+        return dataframe.corr()['variable']['index']
+
+    def is_model_suitable(self, values):
+        dataframe = self.__generate_dataframe(values)
+        pearson_correlation = self.__get_pearson(dataframe)
+        return abs(pearson_correlation) > self.initial_corr_threshold
+
+    def train(self, values):
+        self.dataframe = self.__generate_dataframe(values)
+        self.corr_threshold = self.__get_pearson(self.dataframe)
+
+    def is_anomalous(self, value):
+        new_value_row = pd.Series([ value, len(self.dataframe.index) ], ['variable', 'index'])
+        new_dataframe = self.dataframe.append(new_value_row, ignore_index=True)
+        return self.__get_pearson(new_dataframe) < self.corr_threshold

--- a/src/detectors/TestLinearPearsonAnomalyDetector.py
+++ b/src/detectors/TestLinearPearsonAnomalyDetector.py
@@ -1,0 +1,52 @@
+import unittest
+import numpy as np
+import LinearPearsonAnomalyDetector as detector
+
+class TestLinearPearsonAnomalyDetector(unittest.TestCase):
+    def __get_detector(self):
+        sut = detector.LinearPearsonAnomalyDetector()
+        self.assertIsNotNone(sut)
+        return sut
+
+    def test_is_model_suitable_false_on_constant(self):
+        sut = self.__get_detector()
+
+        self.assertFalse(sut.is_model_suitable([0]))
+        self.assertFalse(sut.is_model_suitable([1, 1]))
+
+    def test_is_model_suitable_linear(self):
+        sut = self.__get_detector()
+
+        self.assertTrue(sut.is_model_suitable([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
+        self.assertTrue(sut.is_model_suitable([10, 9, 8, 7, 6, 5, 4, 3, 2, 1]))
+        self.assertTrue(sut.is_model_suitable([2, 4, 6, 8, 10]))
+
+    def test_is_model_suitable_non_linear(self):
+        sut = self.__get_detector()
+
+        self.assertFalse(sut.is_model_suitable([2, 4, 8, 16, 32, 64, 128, 256]))
+        self.assertFalse(sut.is_model_suitable([2, 4, 6, 8, 10, 8, 6, 4, 2]))
+        self.assertFalse(sut.is_model_suitable([2, 2, 2, 2, 2, 2]))
+        self.assertFalse(sut.is_model_suitable([2, 4, 6, 8, 10, 12, 5]))
+
+    def __is_anomalous_from_dataset(self, dataset, new_value):
+        sut = self.__get_detector()
+
+        sut.train(dataset)
+        return sut.is_anomalous(new_value)
+
+    def test_is_anomalous_false_cases(self):
+        self.assertFalse(self.__is_anomalous_from_dataset([1, 2, 3, 4, 5, 6], 7))
+        self.assertFalse(self.__is_anomalous_from_dataset([2, 3, 4, 5, 6, 7], 8))
+        self.assertFalse(self.__is_anomalous_from_dataset([2, 4, 6, 8], 10))
+        self.assertFalse(self.__is_anomalous_from_dataset([2, 4, 5, 7, 9, 11, 12, 14], 16))
+
+    def test_is_anomalous_true_cases(self):
+        self.assertTrue(self.__is_anomalous_from_dataset([1, 2, 3, 4, 5, 6], 8))
+        self.assertTrue(self.__is_anomalous_from_dataset([2, 3, 4, 5, 6, 7], 6))
+        self.assertTrue(self.__is_anomalous_from_dataset([2, 4, 6, 8], 7))
+        self.assertTrue(self.__is_anomalous_from_dataset([2, 4, 5, 7, 9, 11, 12, 14], 17))
+        self.assertTrue(self.__is_anomalous_from_dataset([2, 4, 5, 7, 9, 11, 12, 14], 14))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/detectors/TestLinearPearsonAnomalyDetector.py
+++ b/src/detectors/TestLinearPearsonAnomalyDetector.py
@@ -45,8 +45,13 @@ class TestLinearPearsonAnomalyDetector(unittest.TestCase):
         self.assertTrue(self.__is_anomalous_from_dataset([1, 2, 3, 4, 5, 6], 8))
         self.assertTrue(self.__is_anomalous_from_dataset([2, 3, 4, 5, 6, 7], 6))
         self.assertTrue(self.__is_anomalous_from_dataset([2, 4, 6, 8], 7))
+        self.assertTrue(self.__is_anomalous_from_dataset([2, 4, 6, 8, 10, 12, 14], 25))
+        self.assertTrue(self.__is_anomalous_from_dataset([2, 4, 6, 8, 10, 12, 14], 15))
+        self.assertTrue(self.__is_anomalous_from_dataset([2, 4, 6, 8, 10, 12, 14], 6))
         self.assertTrue(self.__is_anomalous_from_dataset([2, 4, 5, 7, 9, 11, 12, 14], 17))
         self.assertTrue(self.__is_anomalous_from_dataset([2, 4, 5, 7, 9, 11, 12, 14], 14))
+        self.assertTrue(self.__is_anomalous_from_dataset([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 15))
+        self.assertTrue(self.__is_anomalous_from_dataset([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 1))
 
 if __name__ == '__main__':
     unittest.main()

--- a/vscode.code-workspace
+++ b/vscode.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
Background
-----

These changes are made to detect linear correlations and deviations from the correlations detected in the training ("regular") data. In order to do that, this uses the Pearson Correlation measure, which you can read about in here: https://statistics.laerd.com/spss-tutorials/pearsons-product-moment-correlation-using-spss-statistics.php

Changes
----

- Added `pandas` to the environment
- Added `LinearPearsonAnomalyDetector` and its tests
- Added VS Workspace file (it was accidental, but I think we might benefit from it anyway, so I left it)

Notes
----

- I don't fully like the idea of detecting if the model is suitable with a threshold and then using another one for evaluation. Thoughts on that?